### PR TITLE
modem: Start dbus and modemmanager after boot completed

### DIFF
--- a/manifests/glodroid.xml
+++ b/manifests/glodroid.xml
@@ -30,7 +30,7 @@
   <project path="glodroid/vendor/libcamera/subprojects/libyaml" remote="github"    name="yaml/libyaml.git"   groups="glodroid" revision="refs/tags/0.2.5" />
 
   <!-- modem components (vendor) -->
-  <project path="glodroid/vendor/mm-radio"        remote="glodroid"    name="mm-radio.git"     groups="glodroid" revision="refs/tags/v0.0.2" />
+  <project path="glodroid/vendor/mm-radio"        remote="glodroid"    name="mm-radio.git"     groups="glodroid" revision="90f9f9a8b20ce2e153d39c9fc250ab2733a7fbb9" />
   <project path="glodroid/vendor/mm-radio/vendor" remote="glodroid"    name="mm-radio.git"     groups="glodroid" revision="refs/tags/cargo-deps-2023w07" clone-depth="1" />
   <project path="glodroid/vendor/dbus"            remote="dbus"        name="dbus.git"         groups="glodroid" revision="refs/tags/dbus-1.15.2" />
   <project path="glodroid/vendor/libqmi"          remote="mbroadband"  name="libqmi.git"       groups="glodroid" revision="refs/tags/1.33.4-dev" />

--- a/patches-aosp/glodroid/configuration/0001-modem-Start-dbus-and-modemmanager-after-boot-complet.patch
+++ b/patches-aosp/glodroid/configuration/0001-modem-Start-dbus-and-modemmanager-after-boot-complet.patch
@@ -1,0 +1,28 @@
+From 5a69e42a3b07012794be9514dda114eb9170f8bd Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <r.stratiienko@gmail.com>
+Date: Sun, 19 Mar 2023 21:28:43 +0200
+Subject: [PATCH] modem: Start dbus and modemmanager after boot completed
+
+This change should slightly reduce the boot time.
+
+Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
+---
+ common/modem/modem_manager.rc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/modem/modem_manager.rc b/common/modem/modem_manager.rc
+index bcf564e..2b2f995 100644
+--- a/common/modem/modem_manager.rc
++++ b/common/modem/modem_manager.rc
+@@ -12,7 +12,7 @@ service modemmanager /vendor/bin/ModemManager --debug
+     user root
+     group root
+ 
+-on boot
++on property:sys.boot_completed=1
+     mkdir /mnt/var 0755 system system
+     mkdir /mnt/var/run 0755 system system
+     mkdir /mnt/var/run/dbus 0755 system system
+-- 
+2.34.1
+


### PR DESCRIPTION
This change reduces boot time by 1-2s