### PR TITLE
 Disable the notification about the enabled serial console

### DIFF
--- a/patches-aosp/frameworks/base/0004-GLODROID-Disable-the-notification-about-the-enabled-.patch
+++ b/patches-aosp/frameworks/base/0004-GLODROID-Disable-the-notification-about-the-enabled-.patch
@@ -1,0 +1,31 @@
+From f501ed177ca9e2bc70f51d3b99d495ee49b773c6 Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <r.stratiienko@gmail.com>
+Date: Thu, 30 Nov 2023 05:00:58 +0200
+Subject: [PATCH 4/4] GLODROID: Disable the notification about the enabled
+ serial console
+
+Only critical dmesg outputs are printed into the console,
+therefore, there is no performance impact.
+
+ASigned-off-by: Roman Stratiienko <r.stratiienko@gmail.com>
+Change-Id: Id0a4468a8c66448b834eeeab219acfd74cc158d4
+---
+ .../core/java/com/android/server/am/ActivityManagerService.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/services/core/java/com/android/server/am/ActivityManagerService.java b/services/core/java/com/android/server/am/ActivityManagerService.java
+index 8089dcfe7ebc..79213105fbaf 100644
+--- a/services/core/java/com/android/server/am/ActivityManagerService.java
++++ b/services/core/java/com/android/server/am/ActivityManagerService.java
+@@ -5100,7 +5100,7 @@ public class ActivityManagerService extends IActivityManager.Stub
+     }
+ 
+     private void showConsoleNotificationIfActive() {
+-        if (!SystemProperties.get("init.svc.console").equals("running")) {
++        if (!SystemProperties.get("init.svc.console").equals("running") || true) {
+             return;
+         }
+         String title = mContext
+-- 
+2.39.2
+


### PR DESCRIPTION
Only critical dmesg outputs are printed into the console, therefore, there is no performance impact.